### PR TITLE
Fix rsruby bootstrapping

### DIFF
--- a/Dockerfile.singularity
+++ b/Dockerfile.singularity
@@ -1,8 +1,0 @@
-FROM ubuntu
-USER root
-# START PROVISION
-ADD provision.sh /tmp/provision.sh
-RUN /bin/bash /tmp/provision.sh
-# END PROVISION
-USER rbbt
-ENV HOME /home/rbbt

--- a/share/provision_scripts/gem_setup.sh
+++ b/share/provision_scripts/gem_setup.sh
@@ -9,7 +9,9 @@ gem install --force --no-ri --no-rdoc ZenTest
 gem install --force --no-ri --no-rdoc RubyInline
 
 # R (extra config in gem)
-gem install --conservative --no-ri --no-rdoc rsruby -- --with-R-dir="$R_HOME" --with-R-include="${R_HOME/\/usr\/lib/\/usr\/share}/include" \
+. /etc/profile
+export R_INCLUDE="$(echo "$R_HOME" | sed 's@/usr/lib\(32\|64\)*@/usr/share@')/include"
+gem install --conservative --no-ri --no-rdoc rsruby -- --with-R-dir="$R_HOME" --with-R-include="$R_INCLUDE" \
   --with_cflags="-fPIC -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wall -fno-strict-aliasing"
 
 # Java (extra config in gem)


### PR DESCRIPTION
 - On the fly with the build_rbbt_provision_sh.rb script
 - On enviroments without bash shell (singularity boostrapping)

Tested with:
bin/build_rbbt_provision_sh.rb -ss -sr -sb --nocolor --nobar -dt rbbt-gems -dd mikisvaz/rbbt-system
sudo bin/build_rbbt_provision_sh.rb -ss -sr -su -sb -dd mikisvaz/rbbt-system -si rbbt-gems